### PR TITLE
Fix linux debug and SafeSEH chekc

### DIFF
--- a/Configurations/ConfigClr.cmake
+++ b/Configurations/ConfigClr.cmake
@@ -80,6 +80,16 @@ endfunction()
 
 # Note: We use CMAKE_SIZEOF_VOID_P (void pointer size) to check for x86 vs x64 on a MSVC flag.
 function(_set_target_options_linker_clr targetName)
+	# ----- Environment Checks -----
+	set(SAFESEH_SUPPORTED FALSE) # is only supported on MSVC ABI x86 (Win32) targets.
+	# Windows with MSVC ABI
+	if(MSVC AND (
+		(DEFINED CMAKE_CXX_COMPILER_ARCHITECTURE_ID AND CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "X86") OR
+		(DEFINED CMAKE_C_COMPILER_ARCHITECTURE_ID   AND CMAKE_C_COMPILER_ARCHITECTURE_ID   STREQUAL "X86")
+	))
+		set(SAFESEH_SUPPORTED TRUE)
+	endif()
+
 	# ----- Setup variables -----
 	set(MSVC_DEBUG
 		/DEBUG       # Create a debugging information file for the executable.
@@ -88,21 +98,21 @@ function(_set_target_options_linker_clr targetName)
 		/OPT:NOICF   # Disable identical COMDAT folding. Set by default when /DEBUG is specified.
 	)
 	set(MSVC_RELEASE
-		/LTCG                                          # Link-time code generation. For WholeProgramOptimization.
-		/INCREMENTAL:NO                                # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
-		/OPT:REF                                       # Remove unreferenced functions.   Set by default unless /DEBUG is specified. Disables /INCREMENTAL
-		/OPT:ICF                                       # Enable identical COMDAT folding. Set by default unless /DEBUG is specified.
-		$<$<EQUAL:${CMAKE_SIZEOF_VOID_P},4>:/SAFESEH>  # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
+		/LTCG                                    # Link-time code generation. For WholeProgramOptimization.
+		/INCREMENTAL:NO                          # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
+		/OPT:REF                                 # Remove unreferenced functions.   Set by default unless /DEBUG is specified. Disables /INCREMENTAL
+		/OPT:ICF                                 # Enable identical COMDAT folding. Set by default unless /DEBUG is specified.
+		$<$<BOOL:${SAFESEH_SUPPORTED}>:/SAFESEH> # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
 	)
 	set(MSVC_RELEASE_DEBINFO
 		/DEBUG           # Create a debugging information file for the executable.
 		${MSVC_RELEASE}  # Ensure /OPT explicitly set. Default off due to /DEBUG.
 	)
 	set(MSVC_RELEASE_MINSIZE
-		/INCREMENTAL:NO                                # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
-		/OPT:REF                                       # Remove unreferenced functions.   Set by default unless /DEBUG is specified. Disables /INCREMENTAL
-		/OPT:ICF                                       # Enable identical COMDAT folding. Set by default unless /DEBUG is specified.
-		$<$<EQUAL:${CMAKE_SIZEOF_VOID_P},4>:/SAFESEH>  # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
+		/INCREMENTAL:NO                          # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
+		/OPT:REF                                 # Remove unreferenced functions.   Set by default unless /DEBUG is specified. Disables /INCREMENTAL
+		/OPT:ICF                                 # Enable identical COMDAT folding. Set by default unless /DEBUG is specified.
+		$<$<BOOL:${SAFESEH_SUPPORTED}>:/SAFESEH> # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
 	)
 	
 	# ----- Option: Override Release config -----

--- a/Configurations/ConfigDefault.cmake
+++ b/Configurations/ConfigDefault.cmake
@@ -12,8 +12,7 @@ include("${CMAKE_CURRENT_LIST_DIR}/ConfigMinimal.cmake")
 
 
 # ----- Helper function for configuration -----
-# TODO: Test flags for gcc and clang
-# TODO: MinSizeRel
+# TODO: Test flags for clang
 function(_set_target_options_compiler_def targetName)
 	# ----- Setup variables -----
 	# ----- MSVC compiler flags
@@ -131,23 +130,32 @@ endfunction()
 
 
 function(_set_target_options_linker_def targetName)
-	# ----- Setup variables -----
+	# ----- Environment Checks -----
+	set(SAFESEH_SUPPORTED FALSE) # is only supported on MSVC ABI x86 (Win32) targets.
+	# Windows with MSVC ABI
+	if(MSVC AND (
+		(DEFINED CMAKE_CXX_COMPILER_ARCHITECTURE_ID AND CMAKE_CXX_COMPILER_ARCHITECTURE_ID STREQUAL "X86") OR
+		(DEFINED CMAKE_C_COMPILER_ARCHITECTURE_ID   AND CMAKE_C_COMPILER_ARCHITECTURE_ID   STREQUAL "X86")
+	))
+		set(SAFESEH_SUPPORTED TRUE)
+	endif()
 
+	# ----- Setup variables -----
 	# MSVC linker flags
 	set(MSVC_DEBUG
 		/INCREMENTAL # Link incrementally. Don't always perform a full link.
 	)
 	set(MSVC_RELEASE
-		/LTCG                                          # Link-time code generation. For WholeProgramOptimization.
-		/INCREMENTAL:NO                                # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
-		$<$<EQUAL:${CMAKE_SIZEOF_VOID_P},4>:/SAFESEH>  # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
+		/LTCG                                    # Link-time code generation. For WholeProgramOptimization.
+		/INCREMENTAL:NO                          # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
+		$<$<BOOL:${SAFESEH_SUPPORTED}>:/SAFESEH> # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
 	)
 	set(MSVC_RELEASE_DEBINFO
 		${MSVC_RELEASE}  # /DEBUG inherited from Config::Minimal
 	)
 	set(MSVC_RELEASE_MINSIZE
-		/INCREMENTAL:NO                               # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)	
-		$<$<EQUAL:${CMAKE_SIZEOF_VOID_P},4>:/SAFESEH> # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
+		/INCREMENTAL:NO                          # Always perform a full link. /INCREMENTAL not compatible with /LTCG (in WholeProgramOptimization)
+		$<$<BOOL:${SAFESEH_SUPPORTED}>:/SAFESEH> # Only produces an image if we can produce a table of the image's safe exception handlers. Only valid for x86 targets.
 	)
 
 	# GCC linker flags

--- a/Configurations/GlobalDefaults.cmake
+++ b/Configurations/GlobalDefaults.cmake
@@ -2,7 +2,6 @@ cmake_minimum_required(VERSION 3.27)
 
 include_guard(GLOBAL)
 
-
 # Use this function only on the predefined interface libraries.
 function(set_target_options_warnings targetName)
 	set(MSVC_WARNINGS
@@ -95,12 +94,12 @@ function(set_target_options_macros targetName)
 	)
 	set(GCC_MACROS
 		${DEFAULTS}
-		"$<$<CONFIG:Debug>:_GLIBCXX_DEBUG>" # Enable STL debug checks — similar to /RTC1 spirit
+		"$<$<CONFIG:Debug>:_GLIBCXX_ASSERTIONS>" # Enable ABI-safe libstdc++ assertions for debug builds
 	)
 	set(CLANG_MACROS
 		${DEFAULTS}
-		"$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Darwin>>:_LIBCPP_DEBUG=1>"  # macOS Clang uses libc++
-		"$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Linux>>:_GLIBCXX_DEBUG>"    # Linux Clang uses libstdc++
+		"$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Darwin>>:_LIBCPP_DEBUG=1>"    # macOS Clang uses libc++
+		"$<$<AND:$<CONFIG:Debug>,$<PLATFORM_ID:Linux>>:_GLIBCXX_ASSERTIONS>" # Linux Clang usually uses libstdc++
 	)
 
 	unset(OPTIONS)
@@ -108,8 +107,10 @@ function(set_target_options_macros targetName)
 		set(OPTIONS ${MSVC_MACROS})
 	elseif(CMAKE_CXX_COMPILER_ID STREQUAL "GNU")     # GCC
 		set(OPTIONS   ${GCC_MACROS})
+		message(STATUS "- GNU libstdc++ ABI-safe assertions enabled in Debug builds (_GLIBCXX_ASSERTIONS).")
 	elseif(CMAKE_CXX_COMPILER_ID MATCHES "Clang")    # Clang / AppleClang
 		set(OPTIONS   ${CLANG_MACROS})
+		message(STATUS "- GNU libstdc++ ABI-safe assertions enabled in Debug builds (_GLIBCXX_ASSERTIONS).")
 	else()                                           # Else
 		message(AUTHOR_WARNING "No extra macro definitions set for '${CMAKE_CXX_COMPILER_ID}' compiler.")
 		return()


### PR DESCRIPTION
- SafeSEH only on x86. Previous check allowed arm32 also.
- Fix Linux gcc/clang wrong debug macro defined.